### PR TITLE
removed network interface filters

### DIFF
--- a/src/lib/properties.json
+++ b/src/lib/properties.json
@@ -286,7 +286,7 @@
             "key": "networkInterfaces",
             "normalization": [
                 {
-                    "filterKeys": { "exclude": [ "counters.errorsAll", "counters.dropsAll", "counters.pktsIn", "counters.pktsOut", "mediaActive", "tmName" ] }
+                    "filterKeys": { "exclude": [ ] }
                 },
                 {
                     "renameKeys": { "patterns": { "net/interface": { "pattern": "([0-9]+\\.[0-9]+|(?!\/)mgmt(?=\/))" } } }


### PR DESCRIPTION
@grf5 

#### What issues does this address?
Original repo issue 264

#### What does this change do?
Removes interface filters for drops, errors and pkt counters

#### Where should the reviewer start?
Line 289 of properties.json

#### Any background context?
Customer requested